### PR TITLE
build and upload both arm64 and amd64 images

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -24,5 +24,6 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v4
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: stammw/quinn-interop:latest

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -9,20 +9,20 @@ jobs:
     steps:
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: true
           tags: stammw/quinn-interop:latest


### PR DESCRIPTION
Hi guys! Mac user here 👋

Currently it's not possible to run the Quinn image on my machine:
```
❯ docker run stammw/quinn-interop
Unable to find image 'stammw/quinn-interop:latest' locally
latest: Pulling from stammw/quinn-interop
docker: no matching manifest for linux/arm64/v8 in the manifest list entries.
See 'docker run --help'.
```

This means I can't test against Quinn when running the interop runner locally.

With this PR, a multi-platform build for both arm64 and amd64 is performed. I tested this workflow in my fork, and here's how the result looks: https://hub.docker.com/layers/martenseemann/quinn-interop

The only downside I can see is that the build now takes really long, almost 25 minutes(see [here](https://github.com/marten-seemann/quinn-interop/actions/runs/7435786249/job/20231508279)), compared to 2 minutes before. Coming from Go, I find this quite surprising. I suspect this is because the Rust compiler is super slow, and even more so when cross-compiling. I don't think it ultimately matters if the CI job is taking a few minutes more though.